### PR TITLE
Make maptiler use reqwest::Client to enable http keepavile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "maptiler-cloud"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Luke Newcomb <newcomb.luke@protonmail.com>"]
 description = "A simple Rust wrapper library around the Maptiler Cloud API"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ X and Y coordinates are specified, and a zoom level is specified.
 async fn main() {
     // Create a new Maptiler Cloud session
     // Use your own API key from Maptiler Cloud
-    let maptiler = maptiler_cloud::Maptiler::new("placeholder api key");
+    let maptiler = maptiler_cloud::Maptiler::new("placeholder api key").unwrap();
 
     // Create a new tile request
     let x = 2;

--- a/tests/api.rs
+++ b/tests/api.rs
@@ -6,7 +6,7 @@ use std::env;
 async fn get_tile() {
     let api_key = env::var("MAPTILER_KEY").expect("Environment variable MAPTILER_KEY not set");
 
-    let maptiler = Maptiler::new(api_key);
+    let maptiler = Maptiler::new(api_key).unwrap();
 
     // Gets a satellite view, with zoom 0 (the whole world)
     // The X and Y coordinates of this type must be 0, 0, because there is only one tile in the set


### PR DESCRIPTION
This is a breaking change since MapTiler::new now returns a Result so that it can handle reqwest initialization errors properly. We're still before 1.0, so its not really a problem but id still suggest bumping to 0.3 when this gets merged. 